### PR TITLE
Deprecated `Instance.State` property that used InProcess JSInterop.

### DIFF
--- a/src/KristofferStrube.Blazor.Popper/Instance.cs
+++ b/src/KristofferStrube.Blazor.Popper/Instance.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.JSInterop;
+using System;
 using System.Threading.Tasks;
 
 namespace KristofferStrube.Blazor.Popper;
@@ -6,17 +7,43 @@ namespace KristofferStrube.Blazor.Popper;
 public class Instance
 {
     private readonly IJSObjectReference jSInstance;
-    private readonly IJSInProcessObjectReference popperWrapper;
+    private readonly IJSObjectReference popperWrapper;
 
+    [Obsolete("Only supported in Blazor WASM. ")]
+    private readonly IJSInProcessObjectReference inProcessPopperWrapper;
+
+    [Obsolete("Use the constructor taking a standard IJSObjectReference for the popperWrapper instead. This constructor will be removed in the next major version.")]
     public Instance(IJSObjectReference jSInstance, IJSInProcessObjectReference popperWrapper)
     {
         this.jSInstance = jSInstance;
         this.popperWrapper = popperWrapper;
+        inProcessPopperWrapper = popperWrapper;
     }
+
+    public Instance(IJSObjectReference jSInstance, IJSObjectReference popperWrapper)
+    {
+        this.jSInstance = jSInstance;
+        this.popperWrapper = popperWrapper;
+    }
+
+    [Obsolete("This is only supported in Blazor WASM. Use GetStateAsync instead.")]
     public State State
     {
-        get { return popperWrapper.Invoke<State>("getStateOfInstance", jSInstance); }
+        get
+        {
+            if (inProcessPopperWrapper is null)
+            {
+                throw new InvalidOperationException("Getting the State property is only supported in Blazor WASM.");
+            }
+            return inProcessPopperWrapper.Invoke<State>("getStateOfInstance", jSInstance);
+        }
     }
+
+    public async Task<State> GetStateAsync()
+    {
+        return await popperWrapper.InvokeAsync<State>("getStateOfInstance", jSInstance);
+    }
+
     public async Task ForceUpdate() => await jSInstance.InvokeVoidAsync("forceUpdate");
     public async Task<State> Update() => await popperWrapper.InvokeAsync<State>("updateOnInstance", jSInstance);
     public async Task<State> SetOptions(Options options) => await popperWrapper.InvokeAsync<State>("setOptionsOnInstance", jSInstance, options, options.objRef);

--- a/src/KristofferStrube.Blazor.Popper/Popper.cs
+++ b/src/KristofferStrube.Blazor.Popper/Popper.cs
@@ -15,15 +15,37 @@ public class Popper
 
     public async Task<Instance> CreatePopperAsync(ElementReference reference, ElementReference popper, Options options)
     {
-        var popperWrapper = await jSRuntime.InvokeAsync<IJSInProcessObjectReference>("import", "./_content/KristofferStrube.Blazor.Popper/KristofferStrube.Blazor.popper.js");
-        var jSInstance = await popperWrapper.InvokeAsync<IJSObjectReference>("createPopper", reference, popper, options);
-        return new(jSInstance, popperWrapper);
+        if (jSRuntime is IJSInProcessRuntime)
+        {
+            IJSInProcessObjectReference popperWrapper = await jSRuntime.InvokeAsync<IJSInProcessObjectReference>("import", "./_content/KristofferStrube.Blazor.Popper/KristofferStrube.Blazor.popper.js");
+            IJSObjectReference jSInstance = await popperWrapper.InvokeAsync<IJSObjectReference>("createPopper", reference, popper, options);
+#pragma warning disable CS0618 // Type or member is obsolete
+            return new(jSInstance, popperWrapper);
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+        else
+        {
+            IJSObjectReference popperWrapper = await jSRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/KristofferStrube.Blazor.Popper/KristofferStrube.Blazor.popper.js");
+            IJSObjectReference jSInstance = await popperWrapper.InvokeAsync<IJSObjectReference>("createPopper", reference, popper, options);
+            return new(jSInstance, popperWrapper);
+        }
     }
 
     public async Task<Instance> CreatePopperAsync(VirtualElement reference, ElementReference popper, Options options)
     {
-        var popperWrapper = await jSRuntime.InvokeAsync<IJSInProcessObjectReference>("import", "./_content/KristofferStrube.Blazor.Popper/KristofferStrube.Blazor.popper.js");
-        var jSInstance = await popperWrapper.InvokeAsync<IJSObjectReference>("createPopper", reference, popper, options);
-        return new(jSInstance, popperWrapper);
+        if (jSRuntime is IJSInProcessRuntime)
+        {
+            IJSInProcessObjectReference popperWrapper = await jSRuntime.InvokeAsync<IJSInProcessObjectReference>("import", "./_content/KristofferStrube.Blazor.Popper/KristofferStrube.Blazor.popper.js");
+            IJSObjectReference jSInstance = await popperWrapper.InvokeAsync<IJSObjectReference>("createPopper", reference, popper, options);
+#pragma warning disable CS0618 // Type or member is obsolete
+            return new(jSInstance, popperWrapper);
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+        else
+        {
+            IJSObjectReference popperWrapper = await jSRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/KristofferStrube.Blazor.Popper/KristofferStrube.Blazor.popper.js");
+            IJSObjectReference jSInstance = await popperWrapper.InvokeAsync<IJSObjectReference>("createPopper", reference, popper, options);
+            return new(jSInstance, popperWrapper);
+        }
     }
 }


### PR DESCRIPTION
Made it so instances can be created in Blazor Server and Blazor Hybrid by deprecating InProcess interop from the wrapper.